### PR TITLE
おめでとうございます！あなたはIssue(#6)を解決するPRを受け取りました！

### DIFF
--- a/src/Utils/extendedClient.ts
+++ b/src/Utils/extendedClient.ts
@@ -1,0 +1,10 @@
+import { YTPlayer } from '../classes/player';
+import { ClientOptions, Client } from 'discord.js';
+
+export class extendedClient extends Client {
+	player: YTPlayer | undefined;
+	constructor(options: ClientOptions) {
+		super(options);
+		this.player = undefined;
+	}
+}

--- a/src/commands/changeVolume.ts
+++ b/src/commands/changeVolume.ts
@@ -1,7 +1,8 @@
-import { player } from './play';
+import { client } from '../index';
 import { Message } from 'discord.js';
 
 export async function changeVolumeCommand(message: Message) {
+	const player = client?.player;
 	if (typeof player === 'undefined') return message.reply({ content: '動画が再生されていません。' });
 	if (!message.content.split(' ')[1]) return message.reply({ content: `現在の音量は${player.volume}です。` });
 	if (Number(message.content.split(' ')[1]) > 100) {

--- a/src/commands/loop.ts
+++ b/src/commands/loop.ts
@@ -1,9 +1,10 @@
 import { queueManager, Queue } from '../classes/queue';
 import { embeds } from '../embeds';
-import { player } from './play';
+import { client } from '../index';
 import { Message } from 'discord.js';
 
 export async function loopCommand(message: Message, args: string[]) {
+	const player = client?.player;
 	if (typeof player === 'undefined') return message.reply(embeds.videoNotPlaying);
 	const queue = queueManager.queues.get(message.guildId!) as Queue;
 	args = args.filter((arg) => arg !== '');

--- a/src/commands/nowplaying.ts
+++ b/src/commands/nowplaying.ts
@@ -1,10 +1,11 @@
 import { getSongInfo } from '../Utils/songResolver';
 import { queueManager, Queue } from '../classes/queue';
 import { embeds } from '../embeds';
-import { player } from './play';
+import { client } from '../index';
 import { Message } from 'discord.js';
 
 export async function nowplayingCommand(message: Message) {
+	const player = client?.player;
 	if (typeof player === 'undefined') return message.reply(embeds.videoNotPlaying);
 	const queue = queueManager.getQueue(message.guild?.id as string) as Queue;
 	if (!queue.currentSong) return message.reply(embeds.queueEmpty);

--- a/src/commands/pause.ts
+++ b/src/commands/pause.ts
@@ -1,9 +1,10 @@
 import { embeds } from '../embeds';
-import { player } from './play';
+import { client } from '../index';
 import { AudioPlayerStatus } from '@discordjs/voice';
 import { Message } from 'discord.js';
 
 export async function pauseCommand(message: Message) {
+	const player = client?.player;
 	if (typeof player === 'undefined') return message.reply(embeds.videoNotPlaying);
 
 	if (player.player.state.status === AudioPlayerStatus.Playing) {

--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -1,24 +1,25 @@
 import { YTPlayer } from '../classes/player';
 import { Queue, queueManager } from '../classes/queue';
 import { embeds } from '../embeds';
+import { client } from '../index';
 import { Message, VoiceBasedChannel } from 'discord.js';
 import ytdl from 'ytdl-core';
 
-export let player: YTPlayer | undefined;
-
-export let url: string;
+let url: string;
 
 export async function playCommand(message: Message) {
+	let player = client?.player;
 	if (typeof queueManager.getQueue(message.guild?.id as string) === 'undefined') {
 		queueManager.setQueue(message.guild?.id as string, new Queue());
 	}
 	const queue = queueManager.getQueue(message.guild?.id as string) as Queue;
 	if (typeof player === 'undefined') {
-		player = new YTPlayer(
+		client.player = new YTPlayer(
 			message.guild?.id as string,
 			message.member?.voice.channel as VoiceBasedChannel,
 			message.channel.id
 		);
+		player = client.player;
 	}
 	url = message.content.split(' ')[1];
 	if (!url) return message.reply(embeds.noUrl);

--- a/src/commands/queue.ts
+++ b/src/commands/queue.ts
@@ -1,11 +1,12 @@
 import { songResolver } from '../Utils/songResolver';
 import { Queue, queueManager } from '../classes/queue';
 import { embeds } from '../embeds';
-import { player } from './play';
+import { client } from '../index';
 import { Message } from 'discord.js';
 import ytdl from 'ytdl-core';
 
 export async function queueCommand(message: Message) {
+	const player = client?.player;
 	if (typeof player === 'undefined') return message.reply(embeds.videoNotPlaying);
 	const queue = queueManager.getQueue(message.guildId!) as Queue;
 	if (!queue.length) return message.reply(embeds.queueEmpty);

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -1,9 +1,10 @@
 import { embeds } from '../embeds';
-import { player } from './play';
+import { client } from '../index';
 import { AudioPlayerStatus } from '@discordjs/voice';
 import { Message } from 'discord.js';
 
 export async function resumeCommand(message: Message) {
+	const player = client?.player;
 	if (typeof player === 'undefined') return message.reply(embeds.videoNotPlaying);
 	if (player.player.state.status === AudioPlayerStatus.Paused) {
 		player.resume();

--- a/src/commands/skip.ts
+++ b/src/commands/skip.ts
@@ -1,9 +1,10 @@
 import { Queue, queueManager } from '../classes/queue';
 import { embeds } from '../embeds';
-import { player } from './play';
+import { client } from '../index';
 import { Message } from 'discord.js';
 
 export async function skipCommand(message: Message) {
+	const player = client?.player;
 	if (typeof player === 'undefined') return message.reply(embeds.videoNotPlaying);
 	const queue = queueManager.queues.get(message.guildId!) as Queue;
 	if (!queue.length) return message.reply(embeds.queueEmpty);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@ import { onInteractionCreate } from './Events/onInteractionCreate';
 import { onMessageCreate } from './Events/onMessageCreate';
 import { onReady } from './Events/onReady';
 import { onVoiceStateUpdate } from './Events/onVoiceStateUpdate';
-import { BaseInteraction, Client, GatewayIntentBits, Message, VoiceState } from 'discord.js';
+import { extendedClient as Client } from './Utils/extendedClient';
+import { BaseInteraction, GatewayIntentBits, Message, VoiceState } from 'discord.js';
 import { config } from 'dotenv';
 
 config();

--- a/src/interactions/changeVolume.ts
+++ b/src/interactions/changeVolume.ts
@@ -1,7 +1,8 @@
-import { player } from './play';
+import { client } from '../index';
 import { ChatInputCommandInteraction } from 'discord.js';
 
 export async function changeVolumeCommand(interaction: ChatInputCommandInteraction) {
+	const player = client?.player;
 	if (typeof player === 'undefined') return interaction.reply({ content: '動画が再生されていません。' });
 	const number = interaction.options.getNumber('volume');
 	if (!number) return interaction.reply({ content: `現在の音量は${player.volume}です。` });

--- a/src/interactions/loop.ts
+++ b/src/interactions/loop.ts
@@ -1,9 +1,10 @@
 import { queueManager, Queue } from '../classes/queue';
 import { embeds } from '../embeds';
-import { player } from './play';
+import { client } from '../index';
 import { ChatInputCommandInteraction } from 'discord.js';
 
 export async function loopCommand(interaction: ChatInputCommandInteraction) {
+	const player = client?.player;
 	if (typeof player === 'undefined') return interaction.reply(embeds.videoNotPlaying);
 	const queue = queueManager.queues.get(interaction.guildId!) as Queue;
 	const settings = interaction.options.getString('mode') as string;

--- a/src/interactions/nowplaying.ts
+++ b/src/interactions/nowplaying.ts
@@ -1,10 +1,11 @@
 import { getSongInfo } from '../Utils/songResolver';
 import { queueManager, Queue } from '../classes/queue';
 import { embeds } from '../embeds';
-import { player } from './play';
+import { client } from '../index';
 import { ChatInputCommandInteraction } from 'discord.js';
 
 export async function nowplayingCommand(interaction: ChatInputCommandInteraction) {
+	const player = client?.player;
 	if (typeof player === 'undefined') return interaction.reply(embeds.videoNotPlaying);
 	const queue = queueManager.getQueue(interaction.guild?.id as string) as Queue;
 	if (!queue.currentSong) return interaction.reply(embeds.queueEmpty);

--- a/src/interactions/pause.ts
+++ b/src/interactions/pause.ts
@@ -1,9 +1,10 @@
 import { embeds } from '../embeds';
-import { player } from './play';
+import { client } from '../index';
 import { AudioPlayerStatus } from '@discordjs/voice';
 import { ChatInputCommandInteraction } from 'discord.js';
 
 export async function pauseCommand(interaction: ChatInputCommandInteraction) {
+	const player = client?.player;
 	if (typeof player === 'undefined') return interaction.reply(embeds.videoNotPlaying);
 
 	if (player.player.state.status === AudioPlayerStatus.Playing) {

--- a/src/interactions/play.ts
+++ b/src/interactions/play.ts
@@ -1,14 +1,14 @@
 import { YTPlayer } from '../classes/player';
 import { Queue, queueManager } from '../classes/queue';
 import { embeds } from '../embeds';
+import { client } from '../index';
 import { ChannelType, VoiceBasedChannel, ChatInputCommandInteraction, GuildMember } from 'discord.js';
 import ytdl from 'ytdl-core';
 
-export let player: YTPlayer | undefined;
-
-export let url: string;
+let url: string;
 
 export async function playCommand(interaction: ChatInputCommandInteraction) {
+	let player = client?.player;
 	if (typeof queueManager.getQueue(interaction.guild?.id as string) === 'undefined') {
 		queueManager.setQueue(interaction.guild?.id as string, new Queue());
 	}
@@ -16,11 +16,12 @@ export async function playCommand(interaction: ChatInputCommandInteraction) {
 	if (!interaction.channel) return;
 	if (!(interaction.member instanceof GuildMember)) return;
 	if (typeof player === 'undefined') {
-		player = new YTPlayer(
+		client.player = new YTPlayer(
 			interaction.guild?.id as string,
 			interaction.member?.voice.channel as VoiceBasedChannel,
 			interaction.channel?.id
 		);
+		player = client.player;
 	}
 	url = interaction.options.getString('url') as string;
 	const channel = interaction.member?.voice.channel;

--- a/src/interactions/queue.ts
+++ b/src/interactions/queue.ts
@@ -1,11 +1,12 @@
 import { songResolver } from '../Utils/songResolver';
 import { Queue, queueManager } from '../classes/queue';
 import { embeds } from '../embeds';
-import { player } from './play';
+import { client } from '../index';
 import { ChatInputCommandInteraction } from 'discord.js';
 import ytdl from 'ytdl-core';
 
 export async function queueCommand(interaction: ChatInputCommandInteraction) {
+	const player = client?.player;
 	if (typeof player === 'undefined') return interaction.reply(embeds.videoNotPlaying);
 	const queue = queueManager.getQueue(interaction.guildId!) as Queue;
 	if (!queue.length) return interaction.reply(embeds.queueEmpty);

--- a/src/interactions/resume.ts
+++ b/src/interactions/resume.ts
@@ -1,9 +1,10 @@
 import { embeds } from '../embeds';
-import { player } from './play';
+import { client } from '../index';
 import { AudioPlayerStatus } from '@discordjs/voice';
 import { ChatInputCommandInteraction } from 'discord.js';
 
 export async function resumeCommand(interaction: ChatInputCommandInteraction) {
+	const player = client?.player;
 	if (typeof player === 'undefined') return interaction.reply(embeds.videoNotPlaying);
 	if (player.player.state.status === AudioPlayerStatus.Paused) {
 		player.resume();

--- a/src/interactions/skip.ts
+++ b/src/interactions/skip.ts
@@ -1,9 +1,10 @@
 import { Queue, queueManager } from '../classes/queue';
 import { embeds } from '../embeds';
-import { player } from './play';
+import { client } from '../index';
 import { ChatInputCommandInteraction } from 'discord.js';
 
 export async function skipCommand(interaction: ChatInputCommandInteraction) {
+	const player = client?.player;
 	if (typeof player === 'undefined') return interaction.reply(embeds.videoNotPlaying);
 	const queue = queueManager.queues.get(interaction.guildId!) as Queue;
 	if (!queue.length) return interaction.reply(embeds.queueEmpty);


### PR DESCRIPTION
# 変更内容

dc2b0f917d2d79d585caab1cb988a58dd8502028 │ `Client`を拡張し`extendedClient`を作成しました。playerを内包しています。
https://github.com/MotiCAT/TuneNekoSync/blob/d2bf0b5cedac3ed077acc0be80bb1f7f6ec5bbbb/src/index.ts#L5
https://github.com/MotiCAT/TuneNekoSync/blob/d2bf0b5cedac3ed077acc0be80bb1f7f6ec5bbbb/src/Utils/extendedClient.ts#L1-L10
<hr />
d2bf0b5cedac3ed077acc0be80bb1f7f6ec5bbbb │ 前項の変更により`player`を`play.ts`から参照せず`client.player`を参照するようになりました。
<hr />

これによって [スラッシュコマンドとプレフィックスコマンドで別々のキューになる問題 #6](https://github.com/MotiCAT/TuneNekoSync/issues/6) が解決されます。