### PR TITLE
おめでとうございます！あなたは久しぶりのPRを受け取りました！

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"discord.js": "^14.16.3",
 		"dotenv": "^16.4.5",
 		"ffmpeg-static": "^5.2.0",
+		"node-cache": "^5.1.2",
 		"tweetnacl": "^1.0.3",
 		"youtube-sr": "^4.3.11",
 		"ytpl": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
 	"name": "tunenekosync",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "MusicBot",
 	"main": "index.js",
 	"engines": {
-		"node": ">=18.x"
+		"node": ">=22.x"
 	},
 	"scripts": {
 		"test": "ts-node src/index.ts",
@@ -24,23 +24,24 @@
 	"license": "MIT",
 	"devDependencies": {
 		"@trivago/prettier-plugin-sort-imports": "^4.3.0",
-		"@typescript-eslint/eslint-plugin": "^6.13.1",
-		"@typescript-eslint/parser": "^6.13.1",
-		"eslint": "^8.54.0",
+		"@typescript-eslint/eslint-plugin": "^6.21.0",
+		"@typescript-eslint/parser": "^6.21.0",
+		"eslint": "^8.57.1",
 		"eslint-config-prettier": "^9.1.0",
-		"prettier": "^3.1.0",
-		"ts-node": "^10.9.1",
-		"typescript": "^5.3.2"
+		"prettier": "^3.3.3",
+		"ts-node": "^10.9.2",
+		"typescript": "^5.6.3"
 	},
 	"dependencies": {
 		"@discordjs/opus": "^0.9.0",
 		"@discordjs/voice": "^0.16.1",
-		"discord.js": "^14.14.1",
-		"dotenv": "^16.3.1",
+		"@distube/ytdl-core": "^4.15.1",
+		"discord.js": "^14.16.3",
+		"dotenv": "^16.4.5",
 		"ffmpeg-static": "^5.2.0",
 		"tweetnacl": "^1.0.3",
-		"youtube-sr": "^4.3.10",
-		"ytdl-core": "^4.11.5"
+		"youtube-sr": "^4.3.11",
+		"ytpl": "^2.3.0"
 	},
 	"repository": {
 		"type": "git",

--- a/src/Utils/songResolver.ts
+++ b/src/Utils/songResolver.ts
@@ -1,7 +1,7 @@
 import { format_count, seconds_to_time } from '../Utils/NumberUtil';
 import { client } from '../index';
 import { Builder } from './Builder';
-import ytdl from 'ytdl-core';
+import ytdl from '@distube/ytdl-core';
 
 export function songResolver(info: ytdl.videoInfo, requestedBy?: string, requestedByAvatar?: string) {
 	return {

--- a/src/classes/player.ts
+++ b/src/classes/player.ts
@@ -3,9 +3,9 @@ import { client } from '../index';
 import type { Queue } from './queue';
 import { queueManager } from './queue';
 import { joinVoiceChannel, createAudioPlayer } from '@discordjs/voice';
-import { createAudioResource, StreamType, AudioPlayerStatus } from '@discordjs/voice';
+import { createAudioResource, StreamType, AudioPlayerStatus, DiscordGatewayAdapterCreator } from '@discordjs/voice';
+import ytdl from '@distube/ytdl-core';
 import { Snowflake, VoiceBasedChannel } from 'discord.js';
-import ytdl from 'ytdl-core';
 
 export class YTPlayer {
 	private connection: import('@discordjs/voice').VoiceConnection;
@@ -21,7 +21,7 @@ export class YTPlayer {
 		this.serverId = serverId;
 		this.messageChannelId = messageChannelId;
 		this.connection = joinVoiceChannel({
-			adapterCreator: voiceChannel.guild.voiceAdapterCreator,
+			adapterCreator: voiceChannel.guild.voiceAdapterCreator as DiscordGatewayAdapterCreator,
 			channelId: voiceChannel.id,
 			guildId: serverId,
 			selfDeaf: true,
@@ -99,7 +99,9 @@ export class YTPlayer {
 
 	private async fetchSongData() {
 		const channel = client.channels.cache.get(this.messageChannelId);
-		if (!channel) return;
-		if (channel.isTextBased()) channel.send(await getSongInfo(this.queue.currentSong!));
+		if (!channel || !channel.isTextBased()) return;
+		if (channel.isTextBased() && 'send' in channel) {
+			await channel.send(await getSongInfo(this.queue.currentSong!));
+		}
 	}
 }

--- a/src/classes/player.ts
+++ b/src/classes/player.ts
@@ -87,8 +87,8 @@ export class YTPlayer {
 			else {
 				if (this.queue.store.length >= 1) this.queue.removeSong(0);
 				if (!this.queue.store.length) return this.stop();
-				await this.fetchSongData();
-				return this.play();
+				this.play();
+				return await this.fetchSongData();
 			}
 		}
 		if (this.queue.loop === 'queue') this.queue.loopQueue();

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -1,7 +1,7 @@
 import { songResolver } from '../Utils/songResolver';
 import { embeds } from '../embeds';
+import ytdl from '@distube/ytdl-core';
 import { Message } from 'discord.js';
-import ytdl from 'ytdl-core';
 
 export async function debugCommand(message: Message) {
 	const url = message.content.split(' ')[1];

--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -2,8 +2,8 @@ import { YTPlayer } from '../classes/player';
 import { Queue, queueManager } from '../classes/queue';
 import { embeds } from '../embeds';
 import { client } from '../index';
+import ytdl from '@distube/ytdl-core';
 import { Message, VoiceBasedChannel } from 'discord.js';
-import ytdl from 'ytdl-core';
 
 let url: string;
 

--- a/src/commands/queue.ts
+++ b/src/commands/queue.ts
@@ -2,8 +2,8 @@ import { songResolver } from '../Utils/songResolver';
 import { Queue, queueManager } from '../classes/queue';
 import { embeds } from '../embeds';
 import { client } from '../index';
+import ytdl from '@distube/ytdl-core';
 import { Message } from 'discord.js';
-import ytdl from 'ytdl-core';
 
 export async function queueCommand(message: Message) {
 	const player = client?.player;

--- a/src/interactions/handleplay.ts
+++ b/src/interactions/handleplay.ts
@@ -2,8 +2,8 @@ import { YTPlayer } from '../classes/player';
 import { Queue, queueManager } from '../classes/queue';
 import { embeds } from '../embeds';
 import { client } from '../index';
+import ytdl from '@distube/ytdl-core';
 import { StringSelectMenuInteraction, ChannelType, VoiceBasedChannel, GuildMember } from 'discord.js';
-import ytdl from 'ytdl-core';
 
 let url: string;
 

--- a/src/interactions/play.ts
+++ b/src/interactions/play.ts
@@ -2,8 +2,9 @@ import { YTPlayer } from '../classes/player';
 import { Queue, queueManager } from '../classes/queue';
 import { embeds } from '../embeds';
 import { client } from '../index';
+import ytdl from '@distube/ytdl-core';
 import { ChannelType, VoiceBasedChannel, ChatInputCommandInteraction, GuildMember } from 'discord.js';
-import ytdl from 'ytdl-core';
+import ytpl from 'ytpl';
 
 let url: string;
 
@@ -26,42 +27,58 @@ export async function playCommand(interaction: ChatInputCommandInteraction) {
 	url = interaction.options.getString('url') as string;
 	const channel = interaction.member?.voice.channel;
 	if (!url) return interaction.reply(embeds.noUrl);
-	if (!ytdl.validateURL(url)) return interaction.reply(embeds.invaildUrl);
 	if (!channel) return interaction.reply(embeds.voiceChannelJoin);
 	if (channel.type !== ChannelType.GuildVoice) return;
 	if (!channel.joinable) return interaction.reply(embeds.voiceChannnelJoined);
 	if (!channel.speakable) return interaction.reply(embeds.voiceChannnelPermission);
 
-	if (!queue.length || !player.isPlaying) {
-		queue.addSong(url);
-		const info = await ytdl.getInfo(url);
+	// Check if URL is a playlist
+	if (ytpl.validateID(url)) {
+		const playlist = await ytpl(url);
+		for (const video of playlist.items) queue.addSong(video.url);
+
 		interaction.reply(
 			new embeds.embed()
-				.setTitle('Success')
-				.setDescription(`**[${info.videoDetails.title}](${info.videoDetails.video_url})を再生します。**`)
-				.addFields({
-					name: info.videoDetails.title,
-					value: `投稿者: [${info.videoDetails.author.name}](${info.videoDetails.author.channel_url})`
-				})
-				.setImage(info.videoDetails.thumbnails[0].url.split('?')[0])
+				.setTitle('Playlist Added')
+				.setDescription(`**${playlist.title}** を再生キューに追加しました。`)
 				.setColor('Green')
 				.build()
 		);
-		if (queue.length === 1) return player.play();
+		if (!player.isPlaying) return player.play();
+	} else if (ytdl.validateURL(url)) {
+		if (!queue.length || !player.isPlaying) {
+			queue.addSong(url);
+			const info = await ytdl.getInfo(url);
+			interaction.reply(
+				new embeds.embed()
+					.setTitle('Success')
+					.setDescription(`**[${info.videoDetails.title}](${info.videoDetails.video_url})を再生します。**`)
+					.addFields({
+						name: info.videoDetails.title,
+						value: `投稿者: [${info.videoDetails.author.name}](${info.videoDetails.author.channel_url})`
+					})
+					.setImage(info.videoDetails.thumbnails[0].url.split('?')[0])
+					.setColor('Green')
+					.build()
+			);
+			if (queue.length === 1) return player.play();
+		} else {
+			queue.addSong(url);
+			const info = await ytdl.getInfo(url);
+			interaction.reply(
+				new embeds.embed()
+					.setTitle('Info')
+					.setDescription(`**[${info.videoDetails.title}](${info.videoDetails.video_url})をキューに追加しました。**`)
+					.addFields({
+						name: info.videoDetails.title,
+						value: `投稿者: [${info.videoDetails.author.name}](${info.videoDetails.author.channel_url})`
+					})
+					.setImage(info.videoDetails.thumbnails[0].url.split('?')[0])
+					.setColor('Yellow')
+					.build()
+			);
+		}
 	} else {
-		queue.addSong(url);
-		const info = await ytdl.getInfo(url);
-		interaction.reply(
-			new embeds.embed()
-				.setTitle('Info')
-				.setDescription(`**[${info.videoDetails.title}](${info.videoDetails.video_url})をキューに追加しました。**`)
-				.addFields({
-					name: info.videoDetails.title,
-					value: `投稿者: [${info.videoDetails.author.name}](${info.videoDetails.author.channel_url})`
-				})
-				.setImage(info.videoDetails.thumbnails[0].url.split('?')[0])
-				.setColor('Yellow')
-				.build()
-		);
+		interaction.reply(embeds.invaildUrl);
 	}
 }

--- a/src/interactions/queue.ts
+++ b/src/interactions/queue.ts
@@ -2,27 +2,106 @@ import { songResolver } from '../Utils/songResolver';
 import { Queue, queueManager } from '../classes/queue';
 import { embeds } from '../embeds';
 import { client } from '../index';
-import { ChatInputCommandInteraction } from 'discord.js';
-import ytdl from 'ytdl-core';
+import ytdl from '@distube/ytdl-core';
+import {
+	ChatInputCommandInteraction,
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	ComponentType,
+	EmbedBuilder
+} from 'discord.js';
+
+const SONGS_PER_PAGE = 5;
 
 export async function queueCommand(interaction: ChatInputCommandInteraction) {
 	const player = client?.player;
 	await interaction.deferReply();
 	if (!player) return interaction.followUp(embeds.videoNotPlaying);
-	const queue = queueManager.getQueue(interaction.guildId!) as Queue;
 
-	const embed = new embeds.embed().setTitle('Queue').setColor('Blue').setTimestamp();
-	for (let i = 0; i < queue.length; i++) {
-		const url = queue.store[i];
-		const info = await ytdl.getInfo(url);
-		const song = songResolver(info, interaction.user.username, interaction.user.displayAvatarURL()!);
-		embed.addFields({
-			name: `${i + 1}. ${song.title}`,
-			value: `[${song.author}](${song.authorUrl})`
-		});
-		embed.setFooter({
-			text: `Queue: ${queue.store.length} songs`
-		});
+	const queue = queueManager.getQueue(interaction.guildId!) as Queue;
+	const totalPages = Math.ceil(queue.length / SONGS_PER_PAGE);
+	let currentPage = 0;
+
+	// Helper function to build the queue embed for a specific page
+	async function buildQueueEmbed(page: number): Promise<EmbedBuilder> {
+		const embed = new EmbedBuilder()
+			.setTitle('Queue')
+			.setColor('Blue')
+			.setTimestamp()
+			.setFooter({
+				text: `Page ${page + 1} of ${totalPages} | Queue: ${queue.length} songs`
+			});
+
+		const start = page * SONGS_PER_PAGE;
+		const end = start + SONGS_PER_PAGE;
+		for (let i = start; i < Math.min(end, queue.length); i++) {
+			const url = queue.store[i];
+			const info = await ytdl.getInfo(url);
+			const song = songResolver(info, interaction.user.username, interaction.user.displayAvatarURL()!);
+			embed.addFields({
+				name: `${i + 1}. ${song.title}`,
+				value: `[${song.author}](${song.authorUrl})`
+			});
+		}
+		return embed;
 	}
-	interaction.followUp(embed.build());
+
+	// Initial message with the first page
+	let queueEmbed = await buildQueueEmbed(currentPage);
+	const prevButton = new ButtonBuilder()
+		.setCustomId('prev')
+		.setLabel('Previous')
+		.setStyle(ButtonStyle.Primary)
+		.setDisabled(currentPage === 0);
+	const nextButton = new ButtonBuilder()
+		.setCustomId('next')
+		.setLabel('Next')
+		.setStyle(ButtonStyle.Primary)
+		.setDisabled(currentPage === totalPages - 1);
+
+	const row = new ActionRowBuilder<ButtonBuilder>().addComponents(prevButton, nextButton);
+	const message = await interaction.followUp({ embeds: [queueEmbed], components: [row] });
+
+	// Button interaction collector
+	const collector = message.createMessageComponentCollector({
+		componentType: ComponentType.Button,
+		time: 120000 //2min timeout
+	});
+
+	collector.on('collect', async (buttonInteraction) => {
+		try {
+			// Ensure that the user who clicked the button is the same as the original user
+			if (buttonInteraction.user.id !== interaction.user.id) {
+				return buttonInteraction.reply({ content: "You can't use this button.", ephemeral: true });
+			}
+
+			await buttonInteraction.deferUpdate();
+
+			// Pagination
+			if (buttonInteraction.customId === 'prev') currentPage = Math.max(currentPage - 1, 0);
+			else if (buttonInteraction.customId === 'next') currentPage = Math.min(currentPage + 1, totalPages - 1);
+
+			queueEmbed = await buildQueueEmbed(currentPage);
+			prevButton.setDisabled(currentPage === 0);
+			nextButton.setDisabled(currentPage === totalPages - 1);
+
+			await message.edit({ embeds: [queueEmbed], components: [row] });
+		} catch (error) {
+			console.error('Error updating interaction:', error);
+			// Optionally, send a message to the user if something goes wrong
+			if (buttonInteraction.deferred) {
+				await buttonInteraction.editReply({
+					content: 'An error occurred while updating the interaction.',
+					components: []
+				});
+			}
+		}
+	});
+
+	collector.on('end', () => {
+		prevButton.setDisabled(true);
+		nextButton.setDisabled(true);
+		interaction.editReply({ components: [row] });
+	});
 }

--- a/src/interactions/queue.ts
+++ b/src/interactions/queue.ts
@@ -2,7 +2,7 @@ import { songResolver } from '../Utils/songResolver';
 import { Queue, queueManager } from '../classes/queue';
 import { embeds } from '../embeds';
 import { client } from '../index';
-import ytdl from '@distube/ytdl-core';
+import ytdl, { videoInfo } from '@distube/ytdl-core';
 import {
 	ChatInputCommandInteraction,
 	ActionRowBuilder,
@@ -11,8 +11,20 @@ import {
 	ComponentType,
 	EmbedBuilder
 } from 'discord.js';
+import NodeCache from 'node-cache';
 
 const SONGS_PER_PAGE = 5;
+const infoCache = new NodeCache({ stdTTL: 600 }); // 10分のキャッシュ
+
+// キャッシュされてればキャッシュより動画情報を返す
+async function getCachedInfo(url: string): Promise<videoInfo> {
+	const cached = infoCache.get<videoInfo>(url);
+	if (cached) return cached;
+
+	const info = await ytdl.getInfo(url);
+	infoCache.set(url, info);
+	return info;
+}
 
 export async function queueCommand(interaction: ChatInputCommandInteraction) {
 	const player = client?.player;
@@ -23,7 +35,6 @@ export async function queueCommand(interaction: ChatInputCommandInteraction) {
 	const totalPages = Math.ceil(queue.length / SONGS_PER_PAGE);
 	let currentPage = 0;
 
-	// Helper function to build the queue embed for a specific page
 	async function buildQueueEmbed(page: number): Promise<EmbedBuilder> {
 		const embed = new EmbedBuilder()
 			.setTitle('Queue')
@@ -34,20 +45,31 @@ export async function queueCommand(interaction: ChatInputCommandInteraction) {
 			});
 
 		const start = page * SONGS_PER_PAGE;
-		const end = start + SONGS_PER_PAGE;
-		for (let i = start; i < Math.min(end, queue.length); i++) {
-			const url = queue.store[i];
-			const info = await ytdl.getInfo(url);
+		const end = Math.min(start + SONGS_PER_PAGE, queue.length);
+
+		// 並列で動画情報を取得
+		const songPromises = queue.store.slice(start, end).map((url) => getCachedInfo(url));
+		const songsInfo = await Promise.all(songPromises);
+
+		songsInfo.forEach((info: videoInfo, i: number) => {
 			const song = songResolver(info, interaction.user.username, interaction.user.displayAvatarURL()!);
 			embed.addFields({
-				name: `${i + 1}. ${song.title}`,
+				name: `${start + i + 1}. ${song.title}`,
 				value: `[${song.author}](${song.authorUrl})`
 			});
-		}
+		});
+
 		return embed;
 	}
 
-	// Initial message with the first page
+	// 未キャッシュのキューをバックグラウンドで読み込む
+	async function preloadNextPage(page: number) {
+		const start = page * SONGS_PER_PAGE;
+		const end = Math.min(start + SONGS_PER_PAGE, queue.length);
+		const urls = queue.store.slice(start, end);
+		await Promise.all(urls.map((url) => getCachedInfo(url))); // キャッシュされていない場合のみ取得
+	}
+
 	let queueEmbed = await buildQueueEmbed(currentPage);
 	const prevButton = new ButtonBuilder()
 		.setCustomId('prev')
@@ -63,6 +85,10 @@ export async function queueCommand(interaction: ChatInputCommandInteraction) {
 	const row = new ActionRowBuilder<ButtonBuilder>().addComponents(prevButton, nextButton);
 	const message = await interaction.followUp({ embeds: [queueEmbed], components: [row] });
 
+	// 次ページと次々ページをバックグラウンドで事前読み込み
+	preloadNextPage(currentPage + 1).catch(console.error);
+	if (currentPage + 2 < totalPages) preloadNextPage(currentPage + 2).catch(console.error);
+
 	// Button interaction collector
 	const collector = message.createMessageComponentCollector({
 		componentType: ComponentType.Button,
@@ -72,27 +98,40 @@ export async function queueCommand(interaction: ChatInputCommandInteraction) {
 	collector.on('collect', async (buttonInteraction) => {
 		try {
 			// Ensure that the user who clicked the button is the same as the original user
-			if (buttonInteraction.user.id !== interaction.user.id) {
-				return buttonInteraction.reply({ content: "You can't use this button.", ephemeral: true });
-			}
+			if (buttonInteraction.user.id !== interaction.user.id)
+				return buttonInteraction.reply({ content: 'このボタンは使用できません。', ephemeral: true });
 
 			await buttonInteraction.deferUpdate();
 
 			// Pagination
 			if (buttonInteraction.customId === 'prev') currentPage = Math.max(currentPage - 1, 0);
-			else if (buttonInteraction.customId === 'next') currentPage = Math.min(currentPage + 1, totalPages - 1);
+			else if (buttonInteraction.customId === 'next') {
+				// Nextボタンが押されたら、ラベルを「Loading...」に変更し、ボタンを無効化
+				nextButton.setLabel('Loading...');
+				nextButton.setDisabled(true);
+				await message.edit({ components: [row] });
+
+				// 次ページを読み込む
+				await preloadNextPage(currentPage + 1).catch(console.error);
+				currentPage = Math.min(currentPage + 1, totalPages - 1);
+			}
 
 			queueEmbed = await buildQueueEmbed(currentPage);
 			prevButton.setDisabled(currentPage === 0);
 			nextButton.setDisabled(currentPage === totalPages - 1);
+			nextButton.setLabel('Next'); // 読み込みが完了したら「Next」に戻す
 
 			await message.edit({ embeds: [queueEmbed], components: [row] });
+
+			// 事前読み込みのページ更新
+			if (currentPage + 1 < totalPages) preloadNextPage(currentPage + 1).catch(console.error);
+			if (currentPage + 2 < totalPages) preloadNextPage(currentPage + 2).catch(console.error);
 		} catch (error) {
 			console.error('Error updating interaction:', error);
-			// Optionally, send a message to the user if something goes wrong
+			// エラーが発生した場合、ユーザーにメッセージを送信
 			if (buttonInteraction.deferred) {
 				await buttonInteraction.editReply({
-					content: 'An error occurred while updating the interaction.',
+					content: 'インタラクションの更新中にエラーが発生しました。',
 					components: []
 				});
 			}


### PR DESCRIPTION
fd1ee55690491afad25b50aad2db12f5c3607cc6
└Node.jsのLTSがv22になったためエンジン指定をv22以上に変更しました。
└各依存関係のアップデートを行いました。
└プレイリスト対応のためytplの導入、ytdl-coreがサポートされなくなったため@distube/ytdl-coreへ変更しました。

eeb160928a34c78e4e1f5a262aa6fcd2b1508868 | 型エラー出ていたので修正しました。
2391bc84cd202094cc759aba5a85b39118179e25 | import文の修正です。
1832d87a8d47a92a557c2dabc0eb68e83aa4973b | プレイリストに対応しました。
85cd7ccd1df5e80dbad2e5d31789416403f99148 | キューのページネーションに対応しました。
a4e1a56d6cb435413822f6e6194e3dcd2b28c6c3 | キューの処理高速化のためにキャッシュを導入しました。また非同期でほかページのキューも取得します。
883940fcb722208bb47fc5954dd268ed685a8a1d | プログレスバーを実装しました。また、次の曲がある場合はフッターに記載するようにしました。
a0bc39624f9f4326dce255e5db3e89428f3336e0 | `player.ts`の処理順が違っていたので正規化しました。直さないと2曲目のなうぷれ情報が出た時に前の曲の秒数を表示してから再生を始めてしまいます。